### PR TITLE
update name field menumeal

### DIFF
--- a/src/main/java/com/greenkitchen/portal/controllers/MenuMealController.java
+++ b/src/main/java/com/greenkitchen/portal/controllers/MenuMealController.java
@@ -20,7 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.greenkitchen.portal.dtos.MenuMealRequest;
 import com.greenkitchen.portal.dtos.MenuMealResponse;
 import com.greenkitchen.portal.entities.MenuMeal;
-import com.greenkitchen.portal.enums.Allergen;
+import com.greenkitchen.portal.enums.MenuIngredients;
 import com.greenkitchen.portal.services.MenuMealService;
 import com.greenkitchen.portal.utils.ImageUtils;
 import com.greenkitchen.portal.utils.SlugUtils;
@@ -59,14 +59,14 @@ public class MenuMealController {
         request.setImage(imageUrl);
       }
 
-      // Parse allergensString thành Set<Allergen>
+      // Parse allergensString thành Set<MenuIngredients>
       if (request.getAllergensString() != null && !request.getAllergensString().isEmpty()) {
-        Set<Allergen> allergenSet = Arrays.stream(request.getAllergensString().split(","))
+        Set<MenuIngredients> allergenSet = Arrays.stream(request.getAllergensString().split(","))
             .map(String::trim)
             .map(String::toUpperCase)
-            .map(Allergen::valueOf)
+            .map(MenuIngredients::valueOf)
             .collect(Collectors.toSet());
-        request.setAllergens(allergenSet);
+        request.setMenuIngredients(allergenSet);
       }
 
       MenuMeal menuMeal = menuMealService.createMenuMeal(request);

--- a/src/main/java/com/greenkitchen/portal/dtos/MenuMealRequest.java
+++ b/src/main/java/com/greenkitchen/portal/dtos/MenuMealRequest.java
@@ -2,7 +2,7 @@ package com.greenkitchen.portal.dtos;
 
 import java.util.Set;
 
-import com.greenkitchen.portal.enums.Allergen;
+import com.greenkitchen.portal.enums.MenuIngredients;
 import com.greenkitchen.portal.enums.MenuMealType;
 
 import jakarta.persistence.EnumType;
@@ -28,6 +28,6 @@ public class MenuMealRequest {
     private String image;
     private Double price;
     private String slug;
-    private Set<Allergen> allergens;
+    private Set<MenuIngredients> menuIngredients;
     private String allergensString;
 }

--- a/src/main/java/com/greenkitchen/portal/dtos/MenuMealResponse.java
+++ b/src/main/java/com/greenkitchen/portal/dtos/MenuMealResponse.java
@@ -3,7 +3,7 @@ package com.greenkitchen.portal.dtos;
 import java.util.List;
 import java.util.Set;
 
-import com.greenkitchen.portal.enums.Allergen;
+import com.greenkitchen.portal.enums.MenuIngredients;
 import com.greenkitchen.portal.enums.MenuMealType;
 
 import lombok.AllArgsConstructor;
@@ -27,6 +27,6 @@ public class MenuMealResponse {
   private Double price;
   private String slug;
   private MenuMealType type;
-  private Set<Allergen> allergens;
+  private Set<MenuIngredients> menuIngredients;
   private List<MenuMealReviewResponse> reviews;
 }

--- a/src/main/java/com/greenkitchen/portal/entities/MenuMeal.java
+++ b/src/main/java/com/greenkitchen/portal/entities/MenuMeal.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.greenkitchen.portal.enums.Allergen;
+import com.greenkitchen.portal.enums.MenuIngredients;
 import com.greenkitchen.portal.enums.MenuMealType;
 
 import jakarta.persistence.CascadeType;
@@ -45,7 +45,7 @@ public class MenuMeal extends AbstractEntity {
     @JsonIgnoreProperties("menuMeal")
     private List<MenuMealReview> reviews = new ArrayList<>();
 
-    @ElementCollection(targetClass = Allergen.class)
+    @ElementCollection(targetClass = MenuIngredients.class)
     @Enumerated(EnumType.STRING)
-    private Set<Allergen> allergens = new HashSet<>();
+    private Set<MenuIngredients> menuIngredients = new HashSet<>();
 }

--- a/src/main/java/com/greenkitchen/portal/enums/MenuIngredients.java
+++ b/src/main/java/com/greenkitchen/portal/enums/MenuIngredients.java
@@ -1,6 +1,6 @@
 package com.greenkitchen.portal.enums;
 
-public enum Allergen {
+public enum MenuIngredients {
     GLUTEN,
     PEANUTS,
     TREE_NUTS,

--- a/src/main/java/com/greenkitchen/portal/services/impl/MenuMealServiceImpl.java
+++ b/src/main/java/com/greenkitchen/portal/services/impl/MenuMealServiceImpl.java
@@ -117,11 +117,11 @@ public class MenuMealServiceImpl implements MenuMealService {
         response.setImage(menuMeal.getImage());
         response.setPrice(menuMeal.getPrice());
         response.setSlug(menuMeal.getSlug());
-        if (menuMeal.getAllergens() != null) {
-            response.setAllergens(
-                    menuMeal.getAllergens() != null ? new HashSet<>(menuMeal.getAllergens()) : new HashSet<>());
+        if (menuMeal.getMenuIngredients() != null) {
+            response.setMenuIngredients(
+                    menuMeal.getMenuIngredients() != null ? new HashSet<>(menuMeal.getMenuIngredients()) : new HashSet<>());
         } else {
-            response.setAllergens(new HashSet<>());
+            response.setMenuIngredients(new HashSet<>());
         }
 
         if (menuMeal.getNutrition() != null) {


### PR DESCRIPTION
This pull request refactors the handling of allergens in the menu meal domain to use a more general `MenuIngredients` enum instead of the previous `Allergen` enum. The changes ensure consistency across DTOs, entities, and service layers, and rename the enum file accordingly.

**Refactoring allergen handling to menu ingredients:**

* Replaced all usage of the `Allergen` enum with the new `MenuIngredients` enum in DTOs (`MenuMealRequest`, `MenuMealResponse`), entity (`MenuMeal`), and related logic. [[1]](diffhunk://#diff-ceff1d3437f79a0128e6d02bae4d55304cf802447bddd50bbcf19f14bf7ed316L5-R5) [[2]](diffhunk://#diff-ceff1d3437f79a0128e6d02bae4d55304cf802447bddd50bbcf19f14bf7ed316L31-R31) [[3]](diffhunk://#diff-971daca362c639abdcfebbc6df28d6d512993e50863e17db83e2abc418c84c0aL6-R6) [[4]](diffhunk://#diff-971daca362c639abdcfebbc6df28d6d512993e50863e17db83e2abc418c84c0aL30-R30) [[5]](diffhunk://#diff-b427a18b90de528821bf37a5904302c337c779cfdb633a1aef68119fef6b3b14L9-R9) [[6]](diffhunk://#diff-b427a18b90de528821bf37a5904302c337c779cfdb633a1aef68119fef6b3b14L48-R50) [[7]](diffhunk://#diff-7a26ee26220ca7303e6cf7870c93b546d618e1879fc23a49c4aab5a3806d5107L23-R23) [[8]](diffhunk://#diff-7a26ee26220ca7303e6cf7870c93b546d618e1879fc23a49c4aab5a3806d5107L62-R69) [[9]](diffhunk://#diff-33cbf6398478226f6302a7681b23848dd349f0c08bfe8ed3610d77595d11223eL120-R124)
* Renamed the enum file from `Allergen.java` to `MenuIngredients.java` and updated its contents accordingly.

**API and service layer updates:**

* Updated controller logic to parse and set `MenuIngredients` instead of `Allergen` when handling menu meal creation.
* Modified service implementation to use `MenuIngredients` in response mapping.