### PR TITLE
fix customerId unique and update delete

### DIFF
--- a/src/main/java/com/greenkitchen/portal/entities/Cart.java
+++ b/src/main/java/com/greenkitchen/portal/entities/Cart.java
@@ -23,7 +23,7 @@ import lombok.Setter;
 public class Cart extends AbstractEntity {
   private static final long serialVersionUID = 1L;
 
-  @Column(name = "customer_id")
+  @Column(name = "customer_id", unique = true)
   private Long customerId;
 
   @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/src/main/java/com/greenkitchen/portal/services/impl/CartServiceImpl.java
+++ b/src/main/java/com/greenkitchen/portal/services/impl/CartServiceImpl.java
@@ -150,11 +150,10 @@ public class CartServiceImpl implements CartService {
             throw new RuntimeException("Unauthorized: Item does not belong to this customer");
         }
 
-        // Soft delete - chỉ đánh dấu isDeleted = true
-        cartItem.setIsDeleted(true);
-        cartItemRepository.save(cartItem);
+        cart.getCartItems().remove(cartItem);
 
-        // Update cart total (chỉ tính items không bị xóa)
+        cartItemRepository.delete(cartItem);
+
         cart.setTotalAmount(calculateTotalAmount(cart));
         cartRepository.save(cart);
     }


### PR DESCRIPTION
This pull request introduces a database constraint to ensure that each `customer_id` in the `Cart` entity is unique, and updates the cart item removal logic to perform a hard delete instead of a soft delete. Below are the most important changes:

**Database Model Update:**

* Made the `customer_id` column in the `Cart` entity unique, ensuring that each customer can have only one cart. (`src/main/java/com/greenkitchen/portal/entities/Cart.java`)

**Cart Item Removal Logic:**

* Changed the `removeItemFromCart` method to hard delete cart items from the database instead of marking them as deleted, and updated the cart's total amount accordingly. (`src/main/java/com/greenkitchen/portal/services/impl/CartServiceImpl.java`)